### PR TITLE
Silence py3o.template deprecation warnings during tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,8 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["py3o.template"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::DeprecationWarning:py3o.template.*"
+]


### PR DESCRIPTION
Since we test the deprecated features, no need to warn about them in our own tests.